### PR TITLE
feat: set up GitHub Pages journaling under /journal

### DIFF
--- a/journal/_config.yml
+++ b/journal/_config.yml
@@ -1,0 +1,3 @@
+title: 'Bayko & Brown Bootcamp Journal'
+theme: jekyll-theme-cayman
+description: 'A record of my Networking Bootcamp journey.'

--- a/journal/index.md
+++ b/journal/index.md
@@ -1,0 +1,39 @@
+---
+title: 'Bayko & Brown Bootcamp Journal'
+---
+
+# Bayko & Brown Bootcamp Journal
+
+Networking Fundamentals Bootcamp 2025
+
+This journal documents the architecture, implementation rationale, and technical exploration behind a custom multi-agent orchestration system built for the 2025 Networking Bootcamp.
+
+---
+
+## Contents
+
+| File                                               | Description                                                                                                      |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`tech-uncertainties.md`](./tech-uncertainties.md) | Documentation of unresolved questions, architectural doubts, and decisions made under uncertainty                |
+| [`system-design.md`](./system-design.md)           | Full overview of the architecture, including network layout, agent flow, security models, and tool orchestration |
+| [`architecture-qna.md`](./architecture-qna.md)     | Responses to design review prompts: scope, tradeoffs, defense, scaling, recovery, and conflict resolution        |
+
+---
+
+## Objective
+
+This journal exists to supplement the architecture diagrams and documentation files. It provides reasoning, context, and additional clarity that may not be visible from the static assets alone.
+
+It is structured to address bootcamp requirements and grade evaluation criteria, with emphasis on:
+
+- Networking fundamentals
+- Security design
+- Enterprise architecture alignment
+- Agent orchestration in a zero-trust environment
+
+---
+
+## Related Files
+
+- [Project README](../README.md)
+- [System Architecture](../projects/00-architecture/architecture.md)


### PR DESCRIPTION
This issue tracks the setup of a GitHub Pages blog inside the repo (via /site/ folder) to document the Networking Bootcamp and Bayko & Brown project.

- [ x] Create /journal/ folder with Jekyll structure
- [x ] Add _config.yml, index.md, and starter journal entry
- [ ] Link site in main README
- [ x] Configure Pages: Source → main, Folder → /journal/